### PR TITLE
Remove redundant semicolon

### DIFF
--- a/framework/common/src/com/ilscipio/scipio/web/BrokerSessionConfigurator.java
+++ b/framework/common/src/com/ilscipio/scipio/web/BrokerSessionConfigurator.java
@@ -1,5 +1,5 @@
 package com.ilscipio.scipio.web;
-;
+
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpointConfig;


### PR DESCRIPTION
Remove a redundant semicolon in BrokerSessionConfigurator, which will cause syntax error in Eclipse.